### PR TITLE
Add `contacts` command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,8 @@ Download a [releases](https://github.com/LeBaronDeCharlus/wrs/releases), and add
     let url: String = env::var("URL")?;
     let token: String = env::var("TOKEN")?;
 ```
-Wrike user must be your `Contact ID`, see [this page](https://developers.wrike.com/api/v4/contacts/) for more information.
+
+Wrike user must be your `Contact ID`, to get it, use `wrs contacts --me`.
 
 You need to configure and export them in your $PATH.
 
@@ -26,8 +27,9 @@ You need to configure and export them in your $PATH.
 Usage: wrs [COMMAND]
 
 Commands:
-  tasks  Actions on tasks, default list your tasks
-  help   Print this message or the help of the given subcommand(s)
+  tasks     Actions on tasks, default list your tasks
+  contacts  Actions on contacts, default list your contacts
+  help      Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help
@@ -59,4 +61,28 @@ Searching **my** (--me) task by looking on title **search** (--search) and filte
 +------------------+-----------------+----------+----------------------------------------------+--------+
 | IEABSXDCKRAXO2C7 | Check Mails DNS | Normal   | https://www.wrike.com/open.htm?id=1098344543 | Active |
 +------------------+-----------------+----------+----------------------------------------------+--------+
+```
+
+#### Contacts action
+
+```shell
+> wrs contacts --help
+Actions on contacts, default list your contacts
+
+Usage: wrs contacts [OPTIONS]
+
+Options:
+  -m, --me    Filter by only looking for your own contact
+  -h, --help  Print help
+```
+
+Getting my contact information.
+
+```shell
+> wrs contacts --me
++----------+------------+-----------+------+
+| id       | first_name | last_name | me   |
++----------+------------+-----------+------+
+| JTVXADIP | John       | Doe       | true |
++----------+------------+-----------+------+
 ```

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,6 +15,8 @@ pub struct Cli {
 pub enum Commands {
     /// Actions on tasks, default list your tasks
     Tasks(Tasks),
+    /// Actions on contacts, default list your contacts
+    Contacts(Contacts),
     // Folders(Folders),
 }
 
@@ -36,6 +38,13 @@ pub struct Tasks {
 #[derive(Args, Debug)]
 pub struct Folders {
     pub folders_arg: Option<String>,
+}
+
+#[derive(Debug, Parser)]
+pub struct Contacts {
+    /// Filter by only looking for your own contact
+    #[arg(short, long)]
+    pub me: bool,
 }
 //#[derive(Args, Debug)]
 //pub struct Task {

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -1,0 +1,48 @@
+extern crate prettytable;
+
+use anyhow::{Context, Result};
+use prettytable::{Cell, Row, Table};
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+struct KindContact {
+    kind: String,
+    data: Vec<Contact>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct Contact {
+    id: String,
+    #[serde(rename = "firstName")]
+    first_name: String,
+    #[serde(rename = "lastName")]
+    last_name: String,
+    me: Option<bool>,
+}
+
+pub fn get_contacts<'a>(url: &'a str, path: &'a str, token: &'a str) -> Result<()> {
+    let client = reqwest::blocking::Client::new();
+    let url: String = format!("{}{}", &url, &path);
+    let res = client
+        .get(url)
+        .header(AUTHORIZATION, token)
+        .header(CONTENT_TYPE, "application/json")
+        .header(ACCEPT, "application/json")
+        .send()
+        .context("Failed to make get on url")?;
+
+    let contacts: KindContact = res.json::<KindContact>().context("Could not decode json")?;
+    let mut table = Table::new();
+    table.add_row(row!["id", "first_name", "last_name", "me"]);
+    for i in contacts.data.iter() {
+        table.add_row(Row::new(vec![
+            Cell::new(&i.id),
+            Cell::new(&i.first_name),
+            Cell::new(&i.last_name),
+            Cell::new(&i.me.map_or(String::from(""), |b| b.to_string())),
+        ]));
+    }
+    table.printstd();
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod args;
+mod contacts;
 mod folders;
 mod tasks;
 
@@ -47,6 +48,18 @@ fn main() -> Result<()> {
                 );
                 tasks::get_tasks(&url, &path, &token)?;
             }
+        }
+
+        Some(Commands::Contacts(args)) => {
+            let path = format!(
+                r##"/contacts?{}"##,
+                if args.me {
+                    format!("me=")
+                } else {
+                    String::from("")
+                }
+            );
+            contacts::get_contacts(&url, &path, &token)?;
         }
 
         //        Some(Commands::Folders(_folders_arg)) => {}


### PR DESCRIPTION
The README asks the user to give its `Contact ID` but getting this information is not quite simple to do so this commit adds a command to get it more easily.