### PR TITLE
Add `folders` command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,8 +26,9 @@ You need to configure and export them in your $PATH.
 Usage: wrs [COMMAND]
 
 Commands:
-  tasks  Actions on tasks, default list your tasks
-  help   Print this message or the help of the given subcommand(s)
+  tasks    Actions on tasks, default list your tasks
+  folders  Actions on folders, default list your folders
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help
@@ -59,4 +60,30 @@ Searching **my** (--me) task by looking on title **search** (--search) and filte
 +------------------+-----------------+----------+----------------------------------------------+--------+
 | IEABSXDCKRAXO2C7 | Check Mails DNS | Normal   | https://www.wrike.com/open.htm?id=1098344543 | Active |
 +------------------+-----------------+----------+----------------------------------------------+--------+
+```
+
+
+#### Folders action
+
+```shell
+> wrs folders --help
+
+Actions on folders, default list your folders
+
+Usage: wrs folders [OPTIONS]
+
+Options:
+      --permalink <PERMALINK>  
+  -h, --help
+```
+
+Getting folder information based on its permalink:
+
+```shell
+> wrs folders --permalink="https://www.wrike.com/open.htm?id=1234567890"
++------------------+----------------------+
+| id               | name                 |
++------------------+----------------------+
+| XXXXXXDCI5AY4JYE | My super folder name |
++------------------+----------------------+
 ```

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,7 +15,8 @@ pub struct Cli {
 pub enum Commands {
     /// Actions on tasks, default list your tasks
     Tasks(Tasks),
-    // Folders(Folders),
+    /// Actions on folders, default list your folders
+    Folders(Folders),
 }
 
 #[derive(Debug, Parser)]
@@ -35,10 +36,6 @@ pub struct Tasks {
 
 #[derive(Args, Debug)]
 pub struct Folders {
-    pub folders_arg: Option<String>,
+    #[arg(long)]
+    pub permalink: Option<String>,
 }
-//#[derive(Args, Debug)]
-//pub struct Task {
-//    /// The string to reverse
-//    pub some_action: Option<String>,
-//}

--- a/src/folders.rs
+++ b/src/folders.rs
@@ -18,7 +18,7 @@ struct Folders {
     child_ids: Option<Vec<String>>,
 }
 
-pub fn _get_folders<'a>(url: &'a str, path: &'a str, token: &'a str) -> Result<()> {
+pub fn get_folders<'a>(url: &'a str, path: &'a str, token: &'a str) -> Result<()> {
     let client = reqwest::blocking::Client::new();
     let url: String = format!("{}{}", &url, &path);
     let res = client

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,15 @@ fn main() -> Result<()> {
             }
         }
 
-        //        Some(Commands::Folders(_folders_arg)) => {}
+        Some(Commands::Folders(args)) => {
+            let permalink = match &args.permalink {
+                Some(permalink) => permalink,
+                None => "",
+            };
+            let path = format!(r##"/folders?permalink={}"##, permalink);
+            folders::get_folders(&url, &path, &token)?;
+        }
+
         None => {}
     }
     Ok(())


### PR DESCRIPTION
The `tasks --folder` command requires a folder ID but getting it easily is quite complex. This commit adds the command `folder --permalink` to help getting the folder id.